### PR TITLE
Renamed +defaultCalendar to +defaultCalendarIdentifier, and added corres...

### DIFF
--- a/DateTools/NSDate+DateTools.h
+++ b/DateTools/NSDate+DateTools.h
@@ -150,5 +150,6 @@
 -(NSString *)formattedDateWithFormat:(NSString *)format timeZone:(NSTimeZone *)timeZone locale:(NSLocale *)locale;
 
 #pragma mark - Helpers
-+(NSString *)defaultCalendar;
++(NSString *)defaultCalendarIdentifier;
++ (void)setDefaultCalendarIdentifier:(NSString *)identifier;
 @end

--- a/DateTools/NSDate+DateTools.m
+++ b/DateTools/NSDate+DateTools.m
@@ -47,7 +47,14 @@ static const NSUInteger SHORT_TIME_AGO_STRING_LENGTH = 1;
 
 static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterCalendarUnit | NSMonthCalendarUnit | NSWeekOfYearCalendarUnit | NSWeekOfMonthCalendarUnit | NSDayCalendarUnit | NSHourCalendarUnit | NSMinuteCalendarUnit | NSSecondCalendarUnit | NSEraCalendarUnit | NSWeekdayCalendarUnit | NSWeekdayOrdinalCalendarUnit | NSWeekCalendarUnit;
 
+static NSString *defaultCalendarIdentifier = nil;
+static NSCalendar *implicitCalendar = nil;
+
 @implementation NSDate (DateTools)
+
++ (void)load {
+    [self setDefaultCalendarIdentifier:NSGregorianCalendar];
+}
 
 #pragma mark - Time Ago
 
@@ -326,7 +333,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSInteger
  */
 -(BOOL)isInLeapYear{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *dateComponents = [calendar components:allCalendarUnitFlags fromDate:self];
     
     if (dateComponents.year%400 == 0){
@@ -509,7 +516,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  */
 -(NSInteger)componentForDate:(NSDate *)date type:(DTDateComponent)component calendar:(NSCalendar *)calendar{
     if (!calendar) {
-        calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+        calendar = [[self class] implicitCalendar];
     }
     
     unsigned int unitFlags = 0;
@@ -569,7 +576,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired years
  */
 - (NSDate *)dateByAddingYears:(NSInteger)years{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setYear:years];
     
@@ -584,7 +591,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired months
  */
 - (NSDate *)dateByAddingMonths:(NSInteger)months{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setMonth:months];
     
@@ -599,7 +606,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired weeks
  */
 - (NSDate *)dateByAddingWeeks:(NSInteger)weeks{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setWeek:weeks];
     
@@ -614,7 +621,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired days
  */
 - (NSDate *)dateByAddingDays:(NSInteger)days{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setDay:days];
     
@@ -629,7 +636,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired hours
  */
 - (NSDate *)dateByAddingHours:(NSInteger)hours{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setHour:hours];
     
@@ -644,7 +651,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired minutes
  */
 - (NSDate *)dateByAddingMinutes:(NSInteger)minutes{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setMinute:minutes];
     
@@ -659,7 +666,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired seconds
  */
 - (NSDate *)dateByAddingSeconds:(NSInteger)seconds{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setSecond:seconds];
     
@@ -675,7 +682,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired years
  */
 - (NSDate *)dateBySubtractingYears:(NSInteger)years{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setYear:-1*years];
     
@@ -690,7 +697,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired months
  */
 - (NSDate *)dateBySubtractingMonths:(NSInteger)months{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setMonth:-1*months];
     
@@ -705,7 +712,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired weeks
  */
 - (NSDate *)dateBySubtractingWeeks:(NSInteger)weeks{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setWeek:-1*weeks];
     
@@ -720,7 +727,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired days
  */
 - (NSDate *)dateBySubtractingDays:(NSInteger)days{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setDay:-1*days];
     
@@ -735,7 +742,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired hours
  */
 - (NSDate *)dateBySubtractingHours:(NSInteger)hours{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setHour:-1*hours];
     
@@ -750,7 +757,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired minutes
  */
 - (NSDate *)dateBySubtractingMinutes:(NSInteger)minutes{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setMinute:-1*minutes];
     
@@ -765,7 +772,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  *  @return NSDate - Date modified by the number of desired seconds
  */
 - (NSDate *)dateBySubtractingSeconds:(NSInteger)seconds{
-    NSCalendar *calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+    NSCalendar *calendar = [[self class] implicitCalendar];
     NSDateComponents *components = [[NSDateComponents alloc] init];
     [components setSecond:-1*seconds];
     
@@ -874,7 +881,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  */
 -(NSInteger)yearsFrom:(NSDate *)date calendar:(NSCalendar *)calendar{
     if (!calendar) {
-        calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+        calendar = [[self class] implicitCalendar];
     }
     
     NSDate *earliest = [self earlierDate:date];
@@ -895,7 +902,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  */
 -(NSInteger)monthsFrom:(NSDate *)date calendar:(NSCalendar *)calendar{
     if (!calendar) {
-        calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+        calendar = [[self class] implicitCalendar];
     }
     
     NSDate *earliest = [self earlierDate:date];
@@ -916,7 +923,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  */
 -(NSInteger)weeksFrom:(NSDate *)date calendar:(NSCalendar *)calendar{
     if (!calendar) {
-        calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+        calendar = [[self class] implicitCalendar];
     }
     
     NSDate *earliest = [self earlierDate:date];
@@ -937,7 +944,7 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
  */
 -(NSInteger)daysFrom:(NSDate *)date calendar:(NSCalendar *)calendar{
     if (!calendar) {
-        calendar = [[NSCalendar alloc] initWithCalendarIdentifier:[NSDate defaultCalendar]];
+        calendar = [[self class] implicitCalendar];
     }
     
     NSDate *earliest = [self earlierDate:date];
@@ -1452,12 +1459,31 @@ static const unsigned int allCalendarUnitFlags = NSYearCalendarUnit | NSQuarterC
 }
 
 /**
- *  The default calendar used for all non-calendar-specified operations
+ *  Retrieves the default calendar identifier used for all non-calendar-specified operations
  *
  *  @return NSString - NSCalendarIdentifier
  */
-+(NSString *)defaultCalendar{
-    return NSGregorianCalendar;
++(NSString *)defaultCalendarIdentifier {
+    return defaultCalendarIdentifier;
+}
+
+/**
+ *  Sets the default calendar identifier used for all non-calendar-specified operations
+ *
+ *  @param identifier NSString - NSCalendarIdentifier
+ */
++ (void)setDefaultCalendarIdentifier:(NSString *)identifier {
+    defaultCalendarIdentifier = [identifier copy];
+    implicitCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:defaultCalendarIdentifier ?: NSGregorianCalendar];
+}
+
+/**
+ *  Retrieves a default NSCalendar instance, based on the value of defaultCalendarSetting
+ *
+ *  @return NSCalendar The current implicit calendar
+ */
++ (NSCalendar *)implicitCalendar {
+    return implicitCalendar;
 }
 
 @end


### PR DESCRIPTION
I noticed your performance note about creating NSCalendar objects all over the place, and saw a simple way to fix it by using an implicit calendar instance based on the defaultCalendarIdentieifer. Now it will create a single instance at startup, and another if anyone ever calls +setDefaultCalendarIdentifier. I also renamed +defaultCalendar to +defaultCalendarIdentifier, since that seemed more accurate.

I didn't add any new tests, but the existing test suite still passes.
