### PR TITLE
Localization fix

### DIFF
--- a/DateTools/NSDate+DateTools.m
+++ b/DateTools/NSDate+DateTools.m
@@ -225,7 +225,7 @@ static NSCalendar *implicitCalendar = nil;
 }
 
 - (NSString *)getLocaleFormatUnderscoresWithValue:(double)value{
-    NSString *localeCode = [[NSLocale preferredLanguages] objectAtIndex:0];
+    NSString *localeCode = [[[NSBundle mainBundle] preferredLocalizations] objectAtIndex:0];
     
     // Russian (ru)
     if([localeCode isEqual:@"ru"]) {


### PR DESCRIPTION
This method should use current app localization, but not a device localization. It will return wrong results if app doesn't provide localization for Russian language, but is launched on a phone with Russian language selected.
