### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ All the classes required for DateTools are located in the DateTools folder in th
 * <code>DTTimePeriodCollection.{h,m}</code>
 * <code>DTTimePeriodChain.{h,m}</code>
 
-The following bundle is necessary if you would like to support internationalization. You can add localizations at the `Localizations` subheading under `Info` in the `Project` menu.
+The following bundle is necessary if you would like to support internationalization or would like to use the "Time Ago" functionality. You can add localizations at the `Localizations` subheading under `Info` in the `Project` menu.
 
 * <code>DateTools.bundle</code>
 


### PR DESCRIPTION
It appears that you need to have the DateTools.bundle if you would like to use the "Time Ago" functionality, because it looks up localized strings. The readme was not clear in this regard.