### PR TITLE
Added isSameDay method for #86

### DIFF
--- a/DateTools/NSDate+DateTools.h
+++ b/DateTools/NSDate+DateTools.h
@@ -63,6 +63,7 @@ NSLocalizedStringFromTableInBundle(key, @"DateTools", [NSBundle bundleWithPath:[
 - (BOOL)isTomorrow;
 -(BOOL)isYesterday;
 - (BOOL)isWeekend;
++ (BOOL)isSameDay:(NSDate *)date asDate:(NSDate *)compareDate;
 
 #pragma mark - Date Components With Calendar
 

--- a/DateTools/NSDate+DateTools.m
+++ b/DateTools/NSDate+DateTools.m
@@ -494,6 +494,26 @@ static NSCalendar *implicitCalendar = nil;
     return result;
 }
 
+/**
+ *  Returns whether two dates fall on the same day.
+ *
+ *  @param date NSDate - First date to compare
+ *  @param compareDate NSDate - Second date to compare
+ *  @return BOOL - YES if both paramter dates fall on the same day, NO otherwise
+ */
++ (BOOL)isSameDay:(NSDate *)date asDate:(NSDate *)compareDate
+{
+    NSCalendar *cal = [NSCalendar currentCalendar];
+    
+    NSDateComponents *components = [cal components:(NSCalendarUnitEra|NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay) fromDate:date];
+    NSDate *dateOne = [cal dateFromComponents:components];
+    
+    components = [cal components:(NSCalendarUnitEra|NSCalendarUnitYear|NSCalendarUnitMonth|NSCalendarUnitDay) fromDate:compareDate];
+    NSDate *dateTwo = [cal dateFromComponents:components];
+    
+    return [dateOne isEqualToDate:dateTwo];
+}
+
 #pragma mark - Date Components With Calendar
 /**
  *  Returns the era of the receiver from a given calendar


### PR DESCRIPTION
This adds the desired functionality in issue #86. The static method isSameDay can be used to check if two NSDates fall on the same day.