### PR TITLE
timeAgoSinceDate checks for time intervals between 24 and 48 hrs #100

### DIFF
--- a/DateTools/NSDate+DateTools.m
+++ b/DateTools/NSDate+DateTools.m
@@ -163,6 +163,9 @@ static NSCalendar *implicitCalendar = nil;
 
         return DateToolsLocalizedStrings(@"Yesterday");
     }
+    else if (components.day >= 1) {
+        return [self logicLocalizedStringFromFormat:@"%%d %@day ago" withValue:components.day];
+    }
     else if (components.hour >= 2) {
         return [self logicLocalizedStringFromFormat:@"%%d %@hours ago" withValue:components.hour];
     }
@@ -226,6 +229,9 @@ static NSCalendar *implicitCalendar = nil;
     }
     else if (isYesterday) {
         return [self logicLocalizedStringFromFormat:@"%%d%@d" withValue:1];
+    }
+    else if (components.day >= 1) {
+        return [self logicLocalizedStringFromFormat:@"%%d%@d" withValue:components.day];
     }
     else if (components.hour >= 1) {
         return [self logicLocalizedStringFromFormat:@"%%d%@h" withValue:components.hour];


### PR DESCRIPTION
Solves bug where timeAgoSinceDate and shortTimeAgoSinceDate incorrectly return a number of hours less than 24 if the time since the referenced date is greater than 24 hours and less than 48 hours.

Labels at the bottom of the screen in attached screenshots show the fixed values returned for both timeAgoSinceDate and shortTimeAgoSinceDate.
![Fixed time ago value for 24 hrs < time < 48 hrs](https://cloud.githubusercontent.com/assets/1653722/9612612/7409de30-509b-11e5-9a10-449e734a6a00.png)
![Current time of test](https://cloud.githubusercontent.com/assets/1653722/9612613/758dda7c-509b-11e5-8fd7-a327e10194a4.png)

