### PR TITLE
Added calendarTimeAgoSinceDate methods for feature requested in #100

### DIFF
--- a/DateTools/NSDate+DateTools.h
+++ b/DateTools/NSDate+DateTools.h
@@ -39,7 +39,11 @@ NSLocalizedStringFromTableInBundle(key, @"DateTools", [NSBundle bundleWithPath:[
 - (NSString *)timeAgoSinceDate:(NSDate *)date numericDates:(BOOL)useNumericDates;
 - (NSString *)timeAgoSinceDate:(NSDate *)date numericDates:(BOOL)useNumericDates numericTimes:(BOOL)useNumericTimes;
 - (NSString *)shortTimeAgoSinceDate:(NSDate *)date;
-
+- (NSString *)calendarTimeAgoSinceNow;
+- (NSString *)shortCalendarTimeAgoSinceNow;
+- (NSString *)calendarTimeAgoSinceDate:(NSDate *)date;
+- (NSString *)shortCalendarTimeAgoSinceDate:(NSDate *)date;
+- (NSString *)calendarTimeAgoSinceDate:(NSDate *)date shortFormat:(BOOL)shortFormat;
 
 #pragma mark - Date Components Without Calendar
 - (NSInteger)era;

--- a/DateTools/NSDate+DateTools.m
+++ b/DateTools/NSDate+DateTools.m
@@ -163,6 +163,9 @@ static NSCalendar *implicitCalendar = nil;
 
         return DateToolsLocalizedStrings(@"Yesterday");
     }
+    else if (components.day >= 1) {
+        return [self logicLocalizedStringFromFormat:@"%%d %@day ago" withValue:components.day];
+    }
     else if (components.hour >= 2) {
         return [self logicLocalizedStringFromFormat:@"%%d %@hours ago" withValue:components.hour];
     }
@@ -227,6 +230,9 @@ static NSCalendar *implicitCalendar = nil;
     else if (isYesterday) {
         return [self logicLocalizedStringFromFormat:@"%%d%@d" withValue:1];
     }
+    else if (components.day >= 1) {
+        return [self logicLocalizedStringFromFormat:@"%%d%@d" withValue:components.day];
+    }
     else if (components.hour >= 1) {
         return [self logicLocalizedStringFromFormat:@"%%d%@h" withValue:components.hour];
     }
@@ -273,6 +279,62 @@ static NSCalendar *implicitCalendar = nil;
     
     return @"";
 }
+
+/**
+ *  Returns a string with the most conventient unit of time representing
+ *  how many calendar days in the past that date is from now.
+ *
+ *  @return NSString - Formatted return string
+ */
+- (NSString *)calendarTimeAgoSinceNow
+{
+    return [self calendarTimeAgoSinceDate:[NSDate date]];
+}
+
+/**
+ *  Returns a shortened string with the most conventient unit of time representing
+ *  how many calendar days in the past that date is from now.
+ *
+ *  @return NSString - Formatted return string
+ */
+- (NSString *)shortCalendarTimeAgoSinceNow
+{
+    return [self shortCalendarTimeAgoSinceDate:[NSDate date]];
+}
+
+- (NSString *)calendarTimeAgoSinceDate:(NSDate *)date
+{
+    return [self calendarTimeAgoSinceDate:date shortFormat:NO];
+}
+
+- (NSString *)shortCalendarTimeAgoSinceDate:(NSDate *)date
+{
+    return [self calendarTimeAgoSinceDate:date shortFormat:YES];
+}
+
+- (NSString *)calendarTimeAgoSinceDate:(NSDate *)date shortFormat:(BOOL)shortFormat
+{
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    NSDate *earlierDate = [self earlierDate:date];
+    NSDate *laterDate = (earlierDate == self) ? date : self;
+    
+    NSDate *earliest;
+    NSDate *latest;
+    [calendar rangeOfUnit:NSCalendarUnitDay startDate:&earliest
+                 interval:NULL forDate:earlierDate];
+    [calendar rangeOfUnit:NSCalendarUnitDay startDate:&latest
+                 interval:NULL forDate:laterDate];
+    
+    NSDateComponents *components = [calendar components:NSCalendarUnitDay fromDate:earliest toDate:latest options:0];
+    
+    // If less than one day, return formatted number of hours, minutes, seconds
+    if (components.day < 1) {
+        return shortFormat ? [self shortTimeAgoSinceDate:date] : [self timeAgoSinceDate:date];
+    }
+    
+    return shortFormat ? [latest shortTimeAgoSinceDate:earliest] : [latest timeAgoSinceDate:earliest];
+}
+
 
 #pragma mark - Date Components Without Calendar
 /**


### PR DESCRIPTION
Screenshots show two labels updating calendarTimeAgoSinceNow and shortCalendarTimeAgoSinceNow values as slider is changed (for demonstration only, not included in commit).

![screen shot 2015-09-01 at 2 15 42 pm](https://cloud.githubusercontent.com/assets/1653722/9618999/1f46cf50-50c0-11e5-9e9f-cf5135fc1649.png)
![screen shot 2015-09-01 at 2 14 41 pm](https://cloud.githubusercontent.com/assets/1653722/9618998/1f361b06-50c0-11e5-98e2-55c06bde0413.png)
![screen shot 2015-09-01 at 2 15 00 pm](https://cloud.githubusercontent.com/assets/1653722/9618996/1f31206a-50c0-11e5-968a-80c855ba7fa8.png)
![screen shot 2015-09-01 at 2 15 16 pm](https://cloud.githubusercontent.com/assets/1653722/9618997/1f3484c6-50c0-11e5-9ef5-99331a05f0dc.png)