### PR TITLE
Show the timestamp using hours ago, even if the date is yesterday

### DIFF
--- a/DateTools/NSDate+DateTools.m
+++ b/DateTools/NSDate+DateTools.m
@@ -224,9 +224,6 @@ static NSCalendar *implicitCalendar = nil;
     else if (components.day >= 2) {
         return [self logicLocalizedStringFromFormat:@"%%d%@d" withValue:components.day];
     }
-    else if (isYesterday) {
-        return [self logicLocalizedStringFromFormat:@"%%d%@d" withValue:1];
-    }
     else if (components.hour >= 1) {
         return [self logicLocalizedStringFromFormat:@"%%d%@h" withValue:components.hour];
     }


### PR DESCRIPTION
Hello, 

Please feel free to disregard this, as it really is just an opinion; but it seems that in almost every case of timestamps, it is preferable to show hours all the way up until an entire day has passed. Currently, DateTools show 1d if the data is "yesterday," even if yesterday was just a few hours ago. Typically, a service shows hours until one full day has passed. 

Thanks for your consideration!

Kyle