### PR TITLE
Replaced smart quotes with dumb quotes

### DIFF
--- a/DateTools/DateTools.bundle/hr.lproj/DateTools.strings
+++ b/DateTools/DateTools.bundle/hr.lproj/DateTools.strings
@@ -1,44 +1,44 @@
 /* No comment provided by engineer. */
-"%d days ago" = "%d dana”;
+"%d days ago" = "%d dana";
 
 /* No comment provided by engineer. */
-"%d hours ago" = "%d prime sati”;
+"%d hours ago" = "%d prime sati";
 
 /* No comment provided by engineer. */
-"%d minutes ago" = "%d prije minuta”;
+"%d minutes ago" = "%d prije minuta";
 
 /* No comment provided by engineer. */
-"%d months ago" = "%d prije nekoliko mjeseci”;
+"%d months ago" = "%d prije nekoliko mjeseci";
 
 /* No comment provided by engineer. */
-"%d seconds ago" = "%d sekunde prije”;
+"%d seconds ago" = "%d sekunde prije";
 
 /* No comment provided by engineer. */
-"%d weeks ago" = "%d prije nekoliko tjedana”;
+"%d weeks ago" = "%d prije nekoliko tjedana";
 
 /* No comment provided by engineer. */
-"%d years ago" = "%d prije nekoliko godina”;
+"%d years ago" = "%d prije nekoliko godina";
 
 /* No comment provided by engineer. */
-"A minute ago" = “prije minute";
+"A minute ago" = "prije minute";
 
 /* No comment provided by engineer. */
-"An hour ago" = “prije sat vremena”;
+"An hour ago" = "prije sat vremena";
 
 /* No comment provided by engineer. */
-"Just now" = “upravo sada”;
+"Just now" = "upravo sada";
 
 /* No comment provided by engineer. */
-"Last month" = “prosli mjesec”;
+"Last month" = "prosli mjesec";
 
 /* No comment provided by engineer. */
-"Last week" = "prosli tjedan”;
+"Last week" = "prosli tjedan";
 
 /* No comment provided by engineer. */
-"Last year" = "prosle godine”;
+"Last year" = "prosle godine";
 
 /* No comment provided by engineer. */
-"Yesterday" = “jucer”;
+"Yesterday" = "jucer";
 
 /* No comment provided by engineer. */
-"1 year ago" = “Prije 1 godina”;
+"1 year ago" = "Prije 1 godina";


### PR DESCRIPTION
I was getting this error when compiling a RubyMotion app:

```
2015-10-08 14:59:25.679 plutil[73352:6635954] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 4. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
vendor/Pods/Resources/DateTools.bundle/hr.lproj/DateTools.strings: Property List error: Unexpected character " at line 1 / JSON error: JSON text did not start with array or object and option to allow fragments not set.
```

Removing the smart quotes from this language file fixed the problem.