### PR TITLE
Fix localizatoin of Russian and Ukrainian.

### DIFF
--- a/DateTools/NSDate+DateTools.m
+++ b/DateTools/NSDate+DateTools.m
@@ -267,7 +267,7 @@ static NSCalendar *implicitCalendar = nil;
 }
 
 - (NSString *)getLocaleFormatUnderscoresWithValue:(double)value{
-    NSString *localeCode = [[[NSBundle mainBundle] preferredLocalizations] objectAtIndex:0];
+    NSString *localeCode = [[NSLocale currentLocale] localeIdentifier];
     
     // Russian (ru) and Ukrainian (uk)
     if([localeCode isEqualToString:@"ru"] || [localeCode isEqualToString:@"uk"]) {


### PR DESCRIPTION
Used [[[NSBundle mainBundle] preferredLocalizations] objectAtIndex:0] before returns language name ('Russian') instead of language code ('ru').