### PR TITLE
Fix podspec for cocoapods 1.0.0+

### DIFF
--- a/DateTools.podspec
+++ b/DateTools.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/MatthewYork/DateTools.git",
                      :tag => "v#{s.version.to_s}" }
 
-  s.ios.platform = :ios, '7.0'
-  s.osx.platform = :iox, '10.7'
+  s.platforms = { :ios => '7.0', :osx => '10.7' }
+
   s.requires_arc = true
 
   s.source_files = 'DateTools'


### PR DESCRIPTION
Still compatible with <= 0.39.0.