### PR TITLE
Russian localization strings for shortTimeAgoSinceNow

### DIFF
--- a/DateTools/DateTools.bundle/ru.lproj/DateTools.strings
+++ b/DateTools/DateTools.bundle/ru.lproj/DateTools.strings
@@ -123,3 +123,32 @@
 
 /* No comment provided by engineer. */
 "This year" = "В этом году";
+
+/* Short format for */
+"%dy" = "%d г."; // year
+"%d_y" = "%d г."; // year
+"%d__y" = "%d г."; // year
+
+"%dM" = "%d мес."; // month
+"%d_M" = "%d мес."; // month
+"%d__M" = "%d мес."; // month
+
+"%dw" = "%d нед."; // week
+"%d_w" = "%d нед."; // week
+"%d__w" = "%d нед."; // week
+
+"%dd" = "%d д."; // day
+"%d_d" = "%d д."; // day
+"%d__d" = "%d д."; // day
+
+"%dh" = "%d ч."; // hour
+"%d_h" = "%d ч."; // hour
+"%d__h" = "%d ч."; // hour
+
+"%dm" = "%d мин."; // minute
+"%d_m" = "%d мин."; // minute
+"%d__m" = "%d мин."; // minute
+
+"%ds" = "%d сек."; // second
+"%d_s" = "%d сек."; // second
+"%d__s" = "%d сек."; // second


### PR DESCRIPTION
Hello.

I use your great library for showing short representation of time interval sice now in my news app with  shortTimeAgoSinceNow. But in russian locale result string is not correct. It contains underscore chars.

If i correctly understood logic of code, i add strings in ru.lproj/DateTools.strings

/* Short format for */
"%dy" = "%d г."; // year
"%d_y" = "%d г."; // year
"%d__y" = "%d г."; // year

"%dM" = "%d мес."; // month
"%d_M" = "%d мес."; // month
"%d__M" = "%d мес."; // month

"%dw" = "%d нед."; // week
"%d_w" = "%d нед."; // week
"%d__w" = "%d нед."; // week

"%dd" = "%d д."; // day
"%d_d" = "%d д."; // day
"%d__d" = "%d д."; // day

"%dh" = "%d ч."; // hour
"%d_h" = "%d ч."; // hour
"%d__h" = "%d ч."; // hour

"%dm" = "%d мин."; // minute
"%d_m" = "%d мин."; // minute
"%d__m" = "%d мин."; // minute

"%ds" = "%d сек."; // second
"%d_s" = "%d сек."; // second
"%d__s" = "%d сек."; // second

Now i receive valid result. 

Thanks for your work!