### PR TITLE
swift3

### DIFF
--- a/DateTools.podspec
+++ b/DateTools.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'DateTools'
-  s.version      = '1.7.0'
+  s.version      = '2.0.0-beta.1'
   s.summary      = 'Dates and time made easy in Objective-C'
   s.homepage     = 'https://github.com/MatthewYork/DateTools'
 
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/MatthewYork/DateTools.git",
                      :tag => "v#{s.version.to_s}" }
 
-  s.ios.platform = :ios, '7.0'
-  s.osx.platform = :iox, '10.7'
+  s.ios.deployment_target = '7.0'
+  s.osx.deployment_target = '10.7'
   s.requires_arc = true
 
   s.source_files = 'DateTools'

--- a/DateTools/Date+Comparators.swift
+++ b/DateTools/Date+Comparators.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension Date {
+public extension Date {
 	
 	// MARK: - Addition / Subtractions
 	

--- a/DateTools/Date+Components.swift
+++ b/DateTools/Date+Components.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension Date {
+public extension Date {
 	func component(_ component: Calendar.Component, from date: Date) -> Int {
 		let calendar = Calendar.autoupdatingCurrent
 		return calendar.component(component, from: date)

--- a/DateTools/Date+DateTools.swift
+++ b/DateTools/Date+DateTools.swift
@@ -12,7 +12,7 @@ import Foundation
 
 */
 
-extension Date {
+public extension Date {
     
 	// MARK: - Initializers
     

--- a/DateTools/Date+Format.swift
+++ b/DateTools/Date+Format.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension Date {
+public extension Date {
     
     // MARK: - Formatted Date - Style
     

--- a/DateTools/Date+TimeAgo.swift
+++ b/DateTools/Date+TimeAgo.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension Date {
+public extension Date {
     
     
     //MARK: - Time Ago
@@ -57,16 +57,8 @@ extension Date {
     var shortTimeAgoSinceNow: String {
         return self.shortTimeAgo(since:Date())
     }
-
-    func timeAgo(since date:Date) -> String {
-        return self.timeAgo(since: date, numericDates:false)
-    }
     
-    func timeAgo(since date:Date, numericDates: Bool) -> String {
-        return self.timeAgo(since: date, numericDates: numericDates, numericTimes:false)
-    }
-    
-    func timeAgo(since date:Date, numericDates: Bool, numericTimes: Bool) -> String {
+    func timeAgo(since date:Date, numericDates: Bool = false, numericTimes: Bool = false) -> String {
         let calendar = NSCalendar.current
         let unitFlags = Set<Calendar.Component>([.second,.minute,.hour,.day,.weekOfYear,.month,.year])
         let earliest = self.earlierDate(date)
@@ -204,13 +196,13 @@ extension Date {
     }
 
     
-    func logicalLocalizedStringFromFormat(format: String, value: Int) -> String{
+    private func logicalLocalizedStringFromFormat(format: String, value: Int) -> String{
         let localeFormat = String.init(format: format, getLocaleFormatUnderscoresWithValue(Double(value)))
         return String.init(format: DateToolsLocalizedStrings(localeFormat), value)
     }
     
     
-    func getLocaleFormatUnderscoresWithValue(_ value: Double) -> String{
+    private func getLocaleFormatUnderscoresWithValue(_ value: Double) -> String{
         let localCode = Bundle.main.preferredLocalizations[0]
         if (localCode == "ru" || localCode == "uk") {
             let XY = Int(floor(value).truncatingRemainder(dividingBy: 100))
@@ -234,7 +226,7 @@ extension Date {
 
     
     //MARK: Localization
-    func DateToolsLocalizedStrings(_ string: String) -> String {
+    private func DateToolsLocalizedStrings(_ string: String) -> String {
         //let classBundle = Bundle(for:TimeChunk.self as! AnyClass.Type).resourcePath!.appending("DateTools.bundle")
         
         //let bundelPath = Bundle(path:classBundle)!

--- a/DateTools/Enums.swift
+++ b/DateTools/Enums.swift
@@ -13,7 +13,7 @@
  
  Further reading: [GitHub](https://github.com/MatthewYork/DateTools#relationships), [CodeProject](http://www.codeproject.com/Articles/168662/Time-Period-Library-for-NET)
  */
-enum Relation {
+public enum Relation {
     case after
     case startTouching
     case startInside
@@ -38,7 +38,7 @@ enum Relation {
  
  Open: The boundary moment of time represents a boundary value which is excluded in regard to calculations.
  */
-enum Interval {
+public enum Interval {
     case open
     case closed
 }
@@ -46,7 +46,7 @@ enum Interval {
 /**
  When a time periods is lengthened or shortened, it does so anchoring one date of the time period and then changing the other one. There is also an option to anchor the centerpoint of the time period, changing both the start and end dates.
  */
-enum Anchor {
+public enum Anchor {
     case beginning
     case center
     case end

--- a/DateTools/Integer+DateTools.swift
+++ b/DateTools/Integer+DateTools.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension Int {
+public extension Int {
     
     //MARK: TimePeriod
     var seconds: TimeChunk {

--- a/DateTools/String+DateTools.swift
+++ b/DateTools/String+DateTools.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-extension String {
+public extension String {
 	init(_ date: Date) {
 		self = "\(date)"
 	}

--- a/DateTools/TimeChunk.swift
+++ b/DateTools/TimeChunk.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct TimeChunk {
+public struct TimeChunk {
     
     // MARK: - Variables
     

--- a/DateTools/TimeInterval+Conversion.swift
+++ b/DateTools/TimeInterval+Conversion.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension TimeInterval {
+public extension TimeInterval {
     
     var seconds: Double {
         return self

--- a/DateTools/TimePeriod.swift
+++ b/DateTools/TimePeriod.swift
@@ -16,7 +16,7 @@ import Foundation
  
  [Visit our github page](https://github.com/MatthewYork/DateTools#time-periods) for more information.
  */
-protocol TimePeriodProtocol {
+public protocol TimePeriodProtocol {
     
     // MARK: - Variables
     
@@ -31,7 +31,7 @@ protocol TimePeriodProtocol {
     var end: Date? {get set}
 }
 
-extension TimePeriodProtocol {
+public extension TimePeriodProtocol {
     
     
     // MARK: - Information
@@ -187,17 +187,17 @@ extension TimePeriodProtocol {
  
     [Visit our github page](https://github.com/MatthewYork/DateTools#time-periods) for more information.
  */
-class TimePeriod: TimePeriodProtocol {
+open class TimePeriod: TimePeriodProtocol {
     
     /**
      The start date for a TimePeriod representing the starting boundary of the time period
      */
-    var beginning: Date?
+    public var beginning: Date?
     
     /**
      *  The end date for a TimePeriod representing the ending boundary of the time period
      */
-    var end: Date?
+    public var end: Date?
     
     // MARK: - Initializers
     

--- a/DateTools/TimePeriodChain.swift
+++ b/DateTools/TimePeriodChain.swift
@@ -15,7 +15,7 @@ import Foundation
  
     [Visit our github page](https://github.com/MatthewYork/DateTools#time-period-chains) for more information.
  */
-class TimePeriodChain: TimePeriodGroup {
+open class TimePeriodChain: TimePeriodGroup {
     
     // MARK: - Chain Existence Manipulation
     

--- a/DateTools/TimePeriodCollection.swift
+++ b/DateTools/TimePeriodCollection.swift
@@ -15,7 +15,7 @@ import Foundation
  
     [Visit our github page](https://github.com/MatthewYork/DateTools#time-period-collections) for more information.
  */
-class TimePeriodCollection: TimePeriodGroup {
+open class TimePeriodCollection: TimePeriodGroup {
     
     // MARK: - Collection Manipulation
     

--- a/DateTools/TimePeriodGroup.swift
+++ b/DateTools/TimePeriodGroup.swift
@@ -15,7 +15,7 @@ import Foundation
  
     [Visit our github page](https://github.com/MatthewYork/DateTools#time-period-groups) for more information.
  */
-class TimePeriodGroup: Sequence {
+open class TimePeriodGroup: Sequence {
     
     // MARK: - Variables
     
@@ -67,15 +67,15 @@ class TimePeriodGroup: Sequence {
 
     // MARK: - Sequence Protocol
     
-    func makeIterator() -> IndexingIterator<Array<TimePeriodProtocol>> {
+    public func makeIterator() -> IndexingIterator<Array<TimePeriodProtocol>> {
         return periods.makeIterator()
     }
     
-    internal func map<T>(_ transform: (TimePeriodProtocol) throws -> T) rethrows -> [T] {
+    public func map<T>(_ transform: (TimePeriodProtocol) throws -> T) rethrows -> [T] {
         return try periods.map(transform)
     }
     
-    internal func filter(_ isIncluded: (TimePeriodProtocol) throws -> Bool) rethrows -> [TimePeriodProtocol] {
+    public func filter(_ isIncluded: (TimePeriodProtocol) throws -> Bool) rethrows -> [TimePeriodProtocol] {
         return try periods.filter(isIncluded)
     }
     
@@ -83,11 +83,11 @@ class TimePeriodGroup: Sequence {
         return try periods.reduce(initialResult, nextPartialResult)
     }
     
-    func forEach(_ body: (TimePeriodProtocol) throws -> Void) rethrows {
+    public func forEach(_ body: (TimePeriodProtocol) throws -> Void) rethrows {
         return try periods.forEach(body)
     }
     
-    func split(maxSplits: Int, omittingEmptySubsequences: Bool, whereSeparator isSeparator: (TimePeriodProtocol) throws -> Bool) rethrows -> [AnySequence<TimePeriodProtocol>] {
+    public func split(maxSplits: Int, omittingEmptySubsequences: Bool, whereSeparator isSeparator: (TimePeriodProtocol) throws -> Bool) rethrows -> [AnySequence<TimePeriodProtocol>] {
         return try periods.split(maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences, whereSeparator: isSeparator)
     }
     


### PR DESCRIPTION
- [x] updated the podspec version to `2.0.0-beta.1`
- [x]  improved the access modifiers for swift 3 so that the extension functionality is accessible from another module
- [ ] tag 2.0.0-beta.1

It would be great to start distributing the swift version as a beta on Cocoapods or at least tagged internally. Feel free to change the versioning scheme. I used 2.0.0 as I believe it's the next semantic version for backwards incompatible changes to existing functionality.