### PR TITLE
Small Linux compatibility fix

### DIFF
--- a/DateTools/TimePeriod.swift
+++ b/DateTools/TimePeriod.swift
@@ -91,7 +91,11 @@ public extension TimePeriodProtocol {
         if self.beginning != nil && self.end != nil {
             return abs(self.beginning!.timeIntervalSince(self.end!))
         }
-        return TimeInterval(DBL_MAX)
+        #if os(Linux)
+            return TimeInterval(Double.greatestFiniteMagnitude)
+        #else
+            return TimeInterval(DBL_MAX)
+        #endif
     }
     
     


### PR DESCRIPTION
Fix TimePeriod.swift to be compatible with Linux (where DBL_MAX is not defined)