### PR TITLE
Update Package.swift to support DateToolsSwift again

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
 import PackageDescription
 
 let package = Package(
-    name: "DateTools",
+    name: "DateToolsSwift",
     targets: [
-        Target(name: "DateTools")
+        Target(name: "DateToolsSwift")
     ]
 )
-package.exclude = ["Examples", "Tests"]
+package.exclude = ["DateTools", "Examples", "Tests", "DateToolsSwift/Examples"]


### PR DESCRIPTION
Hi Matthew,

Back in September you accepted a PR of mine to add support for Swift Package Manager (#172). 

Recently I noticed that with the release of DateToolsSwift (congrats!), Swift Package Manager no longer works with it. There are two reasons for this:
1. The Package.swift file needs to be updated. This PR addresses that.
2. The format of your tags doesn't match what SPM expects - you're tagging releases like `v2.0.1` when SPM is expecting just tags like `2.0.1`. (Your beta release tags did match this format - `2.0.0-beta.1` without the `v`. - but you changed your format when you went to full release.)

This PR fixes the first issue, but how would you feel about either changing your tagging system or dual-tagging releases with the SPM format? Unfortunately, I don't think SPM supports a custom tagging scheme.

I still think DateToolsSwift is a perfect example of a library that can and should be dual-sourced for server-side as well as client-side work. Hope you'll consider it!