### PR TITLE
Fix for String cast on Linux

### DIFF
--- a/DateToolsSwift/DateTools/Date+Bundle.swift
+++ b/DateToolsSwift/DateTools/Date+Bundle.swift
@@ -12,7 +12,7 @@ public extension Bundle {
   
   class func dateToolsBundle() -> Bundle {
     let assetPath = Bundle(for: Constants.self).resourcePath!
-    return Bundle(path: (assetPath as NSString).appendingPathComponent("DateTools.bundle"))!
+    return Bundle(path: NSString(string: assetPath).appendingPathComponent("DateTools.bundle"))!
   }
 }
 


### PR DESCRIPTION
Casting String to NSString directly fails on Ubuntu, so this fix accomplishes the same on all platforms. See: http://stackoverflow.com/questions/37293388/cannot-convert-value-of-type-string-to-type-nsstring-in-coercion-when-i-use