### PR TITLE
Add public initializer to TimePeriodGroup

### DIFF
--- a/DateToolsSwift/DateTools/TimePeriodGroup.swift
+++ b/DateToolsSwift/DateTools/TimePeriodGroup.swift
@@ -63,6 +63,11 @@ open class TimePeriodGroup: Sequence {
         return nil
     }
     
+    // MARK: - Initializers
+    
+    public init() {
+        
+    }
     
     // MARK: - Comparisons
     


### PR DESCRIPTION
This change adds a public initializer to `TimePeriodGroup`, allowing external code to create new `TimePeriodCollection` objects. (Resolves https://github.com/MatthewYork/DateTools/issues/188)