### PR TITLE
Fix deprecation warning in Xcode 8.3

### DIFF
--- a/DateToolsSwift/DateTools/TimePeriod.swift
+++ b/DateToolsSwift/DateTools/TimePeriod.swift
@@ -129,11 +129,7 @@ public extension TimePeriodProtocol {
         if self.beginning != nil && self.end != nil {
             return abs(self.beginning!.timeIntervalSince(self.end!))
         }
-        #if os(Linux)
-            return TimeInterval(Double.greatestFiniteMagnitude)
-        #else
-            return TimeInterval(DBL_MAX)
-        #endif
+        return TimeInterval(Double.greatestFiniteMagnitude)
     }
     
     


### PR DESCRIPTION
Xcode 8.3 deprecates DBL_MAX and replaces it with Double.greatestFiniteMagnitude, matching Linux implementation.