### PR TITLE
Fixed some strings

### DIFF
--- a/DateToolsSwift/DateTools/DateTools.bundle/ko.lproj/DateTools.strings
+++ b/DateToolsSwift/DateTools/DateTools.bundle/ko.lproj/DateTools.strings
@@ -26,16 +26,16 @@
 "An hour ago" = "1시간 전";
 
 /* No comment provided by engineer. */
-"Just now" = "방금 전";
+"Just now" = "방금";
 
 /* No comment provided by engineer. */
-"Last month" = "지난 달";
+"Last month" = "지난달";
 
 /* No comment provided by engineer. */
-"Last week" = "지난 주";
+"Last week" = "지난주";
 
 /* No comment provided by engineer. */
-"Last year" = "지난 해";
+"Last year" = "작년";
 
 /* No comment provided by engineer. */
 "Yesterday" = "어제";


### PR DESCRIPTION
Fixed some words according to National Korean Language Institute, 
지난달, 지난주 is correct, instead of 지난 달, 지난 주.
http://www.korean.go.kr/front/mcfaq/mcfaqView.do?mn_id=62&mcfaq_seq=1622

And I believe 작년 is more commonly used than 지난해 for "last year"