### PR TITLE
map to TimePeriodGroup split to AnySequence for Swift 4.1 [hartbit]

### DIFF
--- a/DateToolsSwift/DateTools/TimePeriodGroup.swift
+++ b/DateToolsSwift/DateTools/TimePeriodGroup.swift
@@ -102,7 +102,7 @@ open class TimePeriodGroup: Sequence {
     }
     
     public func split(maxSplits: Int, omittingEmptySubsequences: Bool, whereSeparator isSeparator: (TimePeriodProtocol) throws -> Bool) rethrows -> [AnySequence<TimePeriodProtocol>] {
-        return try periods.split(maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences, whereSeparator: isSeparator)
+        return try periods.split(maxSplits: maxSplits, omittingEmptySubsequences: omittingEmptySubsequences, whereSeparator: isSeparator).map(AnySequence.init)
     }
     
     subscript(index: Int) -> TimePeriodProtocol {


### PR DESCRIPTION
Resolves Swift 4.1 compiler error for Xcode 9.3. Solution by @hartbit in https://github.com/MatthewYork/DateTools/issues/244