### PR TITLE
Patch time ago

### DIFF
--- a/DateToolsSwift/DateTools/Date+Comparators.swift
+++ b/DateToolsSwift/DateTools/Date+Comparators.swift
@@ -44,7 +44,7 @@ public extension Date {
      *  - returns: A TimeChunk representing the time between the dates, in natural form
      */
     public func chunkBetween(date: Date) -> TimeChunk {
-        var compenentsBetween = Calendar.autoupdatingCurrent.dateComponents([.year, .month, .day, .hour, .minute, .second], from: self, to: date)
+        var compenentsBetween = Date.autoupdatingCurrentCalendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: self, to: date)
         return TimeChunk(seconds: compenentsBetween.second!, minutes: compenentsBetween.minute!, hours: compenentsBetween.hour!, days: compenentsBetween.day!, weeks: 0, months: compenentsBetween.month!, years: compenentsBetween.year!)
         // TimeChunk(seconds: secondDelta, minutes: minuteDelta, hours: hourDelta, days: dayDelta, weeks: 0, months: monthDelta, years: yearDelta)
     }
@@ -128,7 +128,7 @@ public extension Date {
      *  - returns: True if both paramter dates fall on the same day, false otherwise
      */
     public static func isSameDay(date: Date, as compareDate: Date) -> Bool {
-        let calendar = Calendar.autoupdatingCurrent
+        let calendar = Date.autoupdatingCurrentCalendar
         var components = calendar.dateComponents([.era, .year, .month, .day], from: date)
         let dateOne = calendar.date(from: components)
         
@@ -262,7 +262,7 @@ public extension Date {
     public func years(from date: Date, calendar: Calendar?) -> Int {
         var calendarCopy = calendar
         if (calendar == nil) {
-            calendarCopy = Calendar.autoupdatingCurrent
+            calendarCopy = Date.autoupdatingCurrentCalendar
         }
         
         let earliest = earlierDate(date)
@@ -286,7 +286,7 @@ public extension Date {
     public func months(from date: Date, calendar: Calendar?) -> Int{
         var calendarCopy = calendar
         if (calendar == nil) {
-            calendarCopy = Calendar.autoupdatingCurrent
+            calendarCopy = Date.autoupdatingCurrentCalendar
         }
         
         let earliest = earlierDate(date)
@@ -310,7 +310,7 @@ public extension Date {
     public func weeks(from date: Date, calendar: Calendar?) -> Int{
         var calendarCopy = calendar
         if (calendar == nil) {
-            calendarCopy = Calendar.autoupdatingCurrent
+            calendarCopy = Date.autoupdatingCurrentCalendar
         }
         
         let earliest = earlierDate(date)
@@ -334,7 +334,7 @@ public extension Date {
     public func days(from date: Date, calendar: Calendar?) -> Int {
         var calendarCopy = calendar
         if (calendar == nil) {
-            calendarCopy = Calendar.autoupdatingCurrent
+            calendarCopy = Date.autoupdatingCurrentCalendar
         }
         
         let earliest = earlierDate(date)

--- a/DateToolsSwift/DateTools/Date+Components.swift
+++ b/DateToolsSwift/DateTools/Date+Components.swift
@@ -24,7 +24,7 @@ public extension Date {
      *
      */
     public func component(_ component: Calendar.Component) -> Int {
-		let calendar = Calendar.autoupdatingCurrent
+		let calendar = Date.autoupdatingCurrentCalendar
 		return calendar.component(component, from: self)
 	}
 	
@@ -38,7 +38,7 @@ public extension Date {
      *
      */
 	public func ordinality(of smaller: Calendar.Component, in larger: Calendar.Component) -> Int? {
-		let calendar = Calendar.autoupdatingCurrent
+		let calendar = Date.autoupdatingCurrentCalendar
 		return calendar.ordinality(of: smaller, in: larger, for: self)
 	}
 	
@@ -55,7 +55,7 @@ public extension Date {
      *
      */
 	public func unit(of smaller: Calendar.Component, in larger: Calendar.Component) -> Int? {
-		let calendar = Calendar.autoupdatingCurrent
+		let calendar = Date.autoupdatingCurrentCalendar
         var units = 1
         var unitRange: Range<Int>?
         if larger.hashValue < smaller.hashValue {
@@ -224,7 +224,7 @@ public extension Date {
      *  Convenience getter for the date's `daysInMonth` component
      */
     public var daysInMonth: Int {
-        let calendar = Calendar.autoupdatingCurrent
+        let calendar = Date.autoupdatingCurrentCalendar
         let days = calendar.range(of: .day, in: .month, for: self)
         return days!.count
     }
@@ -298,7 +298,7 @@ public extension Date {
      *  Determine if date is within the current day
      */
 	public var isToday: Bool {
-		let calendar = Calendar.autoupdatingCurrent
+		let calendar = Date.autoupdatingCurrentCalendar
 		return calendar.isDateInToday(self)
 	}
 	
@@ -306,7 +306,7 @@ public extension Date {
      *  Determine if date is within the day tomorrow
      */
 	public var isTomorrow: Bool {
-		let calendar = Calendar.autoupdatingCurrent
+		let calendar = Date.autoupdatingCurrentCalendar
         return calendar.isDateInTomorrow(self)
 	}
 	
@@ -314,7 +314,7 @@ public extension Date {
      *  Determine if date is within yesterday
      */
 	public var isYesterday: Bool {
-		let calendar = Calendar.autoupdatingCurrent
+		let calendar = Date.autoupdatingCurrentCalendar
         return calendar.isDateInYesterday(self)
 	}
 	

--- a/DateToolsSwift/DateTools/Date+Manipulations.swift
+++ b/DateToolsSwift/DateTools/Date+Manipulations.swift
@@ -13,6 +13,8 @@ import Foundation
  */
 public extension Date {
     
+    static let autoupdatingCurrentCalendar = Calendar.autoupdatingCurrent
+    
     // MARK: - StartOf
     
     /**
@@ -126,7 +128,7 @@ public extension Date {
      *  corresponding `TimeChunk` variables
      */
     public func add(_ chunk: TimeChunk) -> Date {
-        let calendar = Calendar.autoupdatingCurrent
+        let calendar = Date.autoupdatingCurrentCalendar
         var components = DateComponents()
         components.year = chunk.years
         components.month = chunk.months
@@ -147,7 +149,7 @@ public extension Date {
      *  corresponding `TimeChunk` variables
      */
     public func subtract(_ chunk: TimeChunk) -> Date {
-        let calendar = Calendar.autoupdatingCurrent
+        let calendar = Date.autoupdatingCurrentCalendar
         var components = DateComponents()
         components.year = -chunk.years
         components.month = -chunk.months

--- a/DateToolsSwift/DateTools/Date+TimeAgo.swift
+++ b/DateToolsSwift/DateTools/Date+TimeAgo.swift
@@ -68,8 +68,8 @@ public extension Date {
         
         
         let components = calendar.dateComponents(unitFlags, from: earliest, to: latest)
-        let yesterday = date.subtract(1.days)
-        let isYesterday = yesterday.day == self.day
+        let yesterday = latest.subtract(1.days)
+        let isYesterday = yesterday.day == earliest.day
         
         //Not Yet Implemented/Optional
         //The following strings are present in the translation files but lack logic as of 2014.04.05

--- a/DateToolsSwift/DateTools/TimePeriod.swift
+++ b/DateToolsSwift/DateTools/TimePeriod.swift
@@ -129,11 +129,7 @@ public extension TimePeriodProtocol {
         if self.beginning != nil && self.end != nil {
             return abs(self.beginning!.timeIntervalSince(self.end!))
         }
-        #if os(Linux)
-            return TimeInterval(Double.greatestFiniteMagnitude)
-        #else
-            return TimeInterval(DBL_MAX)
-        #endif
+        return TimeInterval(Double.greatestFiniteMagnitude)
     }
     
     


### PR DESCRIPTION
Bug fix for #243 where the `timeAgo` function would fail to return an adequate result of `yesterday`. Looking at the code, it defines `yesterday` as `date.subtract(1.day)`:

```
let yesterday = date.subtract(1.days)
let isYesterday = yesterday.day == self.day
```
But `date` isn't always the later of the two dates, and the code actually computes which of the two dates should be the `latest` and which should be the `earliest`. They're just not being used here. The patch fixes this by ensuring that "yesterday" is the latest date minus 1 day.

```
let yesterday = latest.subtract(1.days)
let isYesterday = yesterday.day == earliest.day
```