### PR TITLE
Bug fix for timeAgo

### DIFF
--- a/DateToolsSwift/DateTools/Date+TimeAgo.swift
+++ b/DateToolsSwift/DateTools/Date+TimeAgo.swift
@@ -68,8 +68,8 @@ public extension Date {
         
         
         let components = calendar.dateComponents(unitFlags, from: earliest, to: latest)
-        let yesterday = date.subtract(1.days)
-        let isYesterday = yesterday.day == self.day
+        let yesterday = latest.subtract(1.days)
+        let isYesterday = yesterday.day == earliest.day
         
         //Not Yet Implemented/Optional
         //The following strings are present in the translation files but lack logic as of 2014.04.05


### PR DESCRIPTION
Bug fix for #243 where the `timeAgo` function would fail to return an adequate result of `yesterday`. Looking at the code, it defines `yesterday` as `date.subtract(1.day)`:

```
let yesterday = date.subtract(1.days)
let isYesterday = yesterday.day == self.day
```
But `date` isn't always the later of the two dates, and the code actually computes which of the two dates should be the `latest` and which should be the `earliest`. They're just not being used here. The patch fixes this by ensuring that "yesterday" is the latest date minus 1 day.

```
let yesterday = latest.subtract(1.days)
let isYesterday = yesterday.day == earliest.day
```