### PR TITLE
Hotfix/fix multi thread error

### DIFF
--- a/DateTools/DateTools/NSDate+DateTools.m
+++ b/DateTools/DateTools/NSDate+DateTools.m
@@ -813,12 +813,8 @@ static NSCalendar *implicitCalendar = nil;
 
 + (NSDate *)dateWithString:(NSString *)dateString formatString:(NSString *)formatString timeZone:(NSTimeZone *)timeZone {
 
-	static NSDateFormatter *parser = nil;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-	    parser = [[NSDateFormatter alloc] init];
-	});
-
+	
+  NSDateFormatter *parser = [[NSDateFormatter alloc] init];
 	parser.dateStyle = NSDateFormatterNoStyle;
 	parser.timeStyle = NSDateFormatterNoStyle;
 	parser.timeZone = timeZone;
@@ -1619,12 +1615,8 @@ static NSCalendar *implicitCalendar = nil;
  *  @return NSString representing the formatted date string
  */
 -(NSString *)formattedDateWithStyle:(NSDateFormatterStyle)style timeZone:(NSTimeZone *)timeZone locale:(NSLocale *)locale{
-    static NSDateFormatter *formatter = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        formatter = [[NSDateFormatter alloc] init];
-    });
-
+  
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     [formatter setDateStyle:style];
     [formatter setTimeZone:timeZone];
     [formatter setLocale:locale];

--- a/DateTools/DateTools/NSDate+DateTools.m
+++ b/DateTools/DateTools/NSDate+DateTools.m
@@ -1677,12 +1677,8 @@ static NSCalendar *implicitCalendar = nil;
  *  @return NSString representing the formatted date string
  */
 -(NSString *)formattedDateWithFormat:(NSString *)format timeZone:(NSTimeZone *)timeZone locale:(NSLocale *)locale{
-    static NSDateFormatter *formatter = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        formatter = [[NSDateFormatter alloc] init];
-    });
-
+  
+    NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     [formatter setDateFormat:format];
     [formatter setTimeZone:timeZone];
     [formatter setLocale:locale];


### PR DESCRIPTION
when call -(NSString *)formattedDateWithFormat:(NSString *)format in multi thread the result may be error for example:

for (NSInteger index = 0; index < 1000; index++) {
    
    if (index % 2 ==0) {
      [NSThread detachNewThreadWithBlock:^{
       NSLog(@"test1:%@",[[NSDate date] formattedDateWithFormat:@"yyyy-MM-dd"]);
      }];
    }else{
      [NSThread detachNewThreadWithBlock:^{
         NSLog(@"test2:%@",[[NSDate date] formattedDateWithFormat:@"yyyy-MM-dd HH:mm:ss.SSS"]);
      }];
    }
    
  }

the results is:

2018-04-13 14:07:14.355993+0800 TestDemo_Example[21257:35085629] test1:2018-04-13
2018-04-13 14:07:14.422793+0800 TestDemo_Example[21257:35085632] test2:2018-04-13
2018-04-13 14:07:14.422932+0800 TestDemo_Example[21257:35085631] test1:2018-04-13
2018-04-13 14:07:14.423280+0800 TestDemo_Example[21257:35085633] test1:2018-04-13 14:07:14.354
2018-04-13 14:07:14.423508+0800 TestDemo_Example[21257:35085634] test2:2018-04-13 14:07:14.354
2018-04-13 14:07:14.424189+0800 TestDemo_Example[21257:35085635] test1:2018-04-13 14:07:14.354
2018-04-13 14:07:14.424334+0800 TestDemo_Example[21257:35085637] test1:2018-04-13 14:07:14.354
2018-04-13 14:07:14.424579+0800 TestDemo_Example[21257:35085638] test2:2018-04-13