### PR TITLE
Add support for SwiftPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ DerivedData
 
 #CocoaPods
 Pods
+
+#swiftpm
+.swiftpm
+*.xcodeproj

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateComparatorsExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateComparatorsExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateComparatorsTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateComponentsExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateComponentsExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateComponentsTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateFormatExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateFormatExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateFormatTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateInitsExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateInitsExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateDateToolsTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateManipulationsExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateManipulationsExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateManipulationsTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateTimeAgoExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateTimeAgoExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateTimeAgoTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/IntegerExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/IntegerExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class IntegerTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimeAgoTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimeAgoTests.swift
@@ -7,22 +7,29 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 
 class TimeAgoTests : XCTestCase {
     
-    var formatter: DateFormatter?
-    var date0: Date?
-    var date1: Date?
+    var formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy MM dd HH:mm:ss.SSS"
+        return formatter
+    }()
+    var date0 = Date()
+    var date1 = Date()
     
     override func setUp() {
-        super.up = nil
+        super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
-        self.formatter = DateFormatter()
-        self.formatter?.dateFormat = "yyyy MM dd HH:mm:ss.SSS"
-        self.date0 = self.formatter?.date(from: "2014 11 05 18:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
+        
+        do {
+            self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 05 18:15:12.000"))
+            self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        } catch {
+            XCTFail("Failed to format dates from string.")
+        }
     }
     
     override func tearDown() {
@@ -31,112 +38,118 @@ class TimeAgoTests : XCTestCase {
     }
     
     func testBasicLongTimeAgo() {
-        var now: String = self.date0.timeAgoSinceDate(self.date0)
-        XCTAssert(now && now.length > 0, "'Now' is nil or empty.")
-        var ago: String = self.date1.timeAgoSinceDate(self.date0)
-        XCTAssert(ago && ago.length > 0, "Ago is nil or empty.")
+        let now: String = self.date0.timeAgo(since: self.date0)
+        XCTAssert(now.isEmpty, "'Now' is empty.")
+        let ago: String = self.date1.timeAgo(since: self.date0)
+        XCTAssert(ago.isEmpty, "Ago is empty.")
     }
     
-    func testLongTimeAgo2Days() {
-        self.date0 = self.formatter?.date(from: "2014 11 05 18:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("2 days ago"))
+    func testLongTimeAgo2Days() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 05 18:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("2 days ago"))
     }
     
-    func testLongTimeAgo1DayAndHalf() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 9:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("Yesterday"))
+    func testLongTimeAgo1DayAndHalf() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 9:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("Yesterday"))
     }
     
-    func testLongTimeAgoExactlyYesterday() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 18:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("Yesterday"))
+    func testLongTimeAgoExactlyYesterday() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 18:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("Yesterday"))
     }
     
-    func testLongTimeAgoLessThan24hoursButYesterday() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 20:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("22 hours ago"))
+    func testLongTimeAgoLessThan24hoursButYesterday() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 20:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("22 hours ago"))
     }
     
-    func testLongTimeAgoLessThan24hoursSameDay() {
-        self.date0 = self.formatter?.date(from: "2014 11 07 10:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("8 hours ago"))
+    func testLongTimeAgoLessThan24hoursSameDay() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("8 hours ago"))
     }
     
-    func testLongTimeAgoBetween24And48Hours() {
-        self.date0 = self.formatter?.date(from: "2014 11 07 10:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 08 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("Yesterday"))
+    func testLongTimeAgoBetween24And48Hours() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 08 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("Yesterday"))
     }
     
     func testBasicShortTimeAgo() {
-        var now: String = self.date0.shortTimeAgoSinceDate(self.date0)
-        XCTAssert(now && now.length > 0, "'Now' is nil or empty.")
-        var ago: String = self.date1.shortTimeAgoSinceDate(self.date0)
-        XCTAssert(ago && ago.length > 0, "Ago is nil or empty.")
+        let now: String = self.date0.shortTimeAgo(since: self.date0)
+        XCTAssertFalse(now.isEmpty, "'Now' is empty.")
+        let ago: String = self.date1.shortTimeAgo(since: self.date0)
+        XCTAssertFalse(ago.isEmpty, "Ago is empty.")
     }
     
-    func testShortTimeAgo2Days() {
-        self.date0 = self.formatter?.date(from: "2014 11 05 18:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("2d"))
+    func testShortTimeAgo2Days() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 05 18:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("2d"))
     }
     
-    func testShortTimeAgo1DayAndHalf() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 9:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("1d"))
+    func testShortTimeAgo1DayAndHalf() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 9:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("1d"))
     }
     
-    func testShortTimeAgoExactlyYesterday() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 18:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("1d"))
+    func testShortTimeAgoExactlyYesterday() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 18:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("1d"))
     }
     
-    func testShortTimeAgoLessThan24hoursButYesterday() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 20:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("22h"))
+    func testShortTimeAgoLessThan24hoursButYesterday() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 20:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("22h"))
     }
     
-    func testShortTimeAgoLessThan24hoursSameDay() {
-        self.date0 = self.formatter?.date(from: "2014 11 07 10:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("8h"))
+    func testShortTimeAgoLessThan24hoursSameDay() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("8h"))
     }
     
-    func testShortTimeAgoBetween24And48Hours() {
-        self.date0 = self.formatter?.date(from: "2014 11 07 10:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 08 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("1d"))
+    func testShortTimeAgoBetween24And48Hours() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 08 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("1d"))
     }
     
-    func testLongTimeAgoLocalizationsAccessible() {
-        var en_local: String = "Yesterday"
-        var ja_local: String = "昨日"
-        var key: String = en_local
-        var path: String = NSBundlemainBundle.bundlePath.stringByAppendingPathComponent("DateTools.bundle/ja.lproj")
-        var bundle: Bundle = Bundle(path: path)!
-        var ja_result: String = NSLocalizedStringFromTableInBundle(key, "DateTools", bundle, nil)
-        XCTAssertEqualObjects(ja_local, ja_result, "Could not access localizations.")
+    func testLongTimeAgoLocalizationsAccessible() throws {
+        let en_local: String = "Yesterday"
+        let ja_local: String = "昨日"
+        let key: String = en_local
+        let ja_result: String = DateToolsLocalizedStrings(key)
+        XCTAssertEqual(ja_local, ja_result, "Could not access localizations.")
     }
-    
 }
 
+extension XCTestCase {
+    func DateToolsLocalizedStrings(_ key: String) -> String {
+        return NSLocalizedString(key,
+                                 tableName: "DateTools",
+                                 bundle: Bundle.dateToolsBundle(),
+                                 value: "",
+                                 comment: "")
+    }
+}

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimeChunkTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimeChunkTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class TimeChunkTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodChainTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodChainTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 
 class TimePeriodChainTests : XCTestCase {

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodCollectionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodCollectionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class TimePeriodCollectionTests : XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodGroupTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodGroupTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 
 class TimePeriodGroupTests : XCTestCase {

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class TimePeriodTests : XCTestCase {
     

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,30 @@
+// swift-tools-version:5.1
+
 import PackageDescription
 
 let package = Package(
     name: "DateToolsSwift",
+    platforms: [
+        .macOS(.v10_10), .iOS(.v8)
+    ],
+    products: [
+        .library(
+            name: "DateToolsSwift",
+            targets: ["DateToolsSwift"])
+    ],
     targets: [
-        Target(name: "DateToolsSwift")
+        .target(
+            name: "DateToolsSwift",
+            path: "DateToolsSwift/DateTools",
+            exclude: [
+                "Examples",
+                "DateToolsSwift/Examples"
+            ]
+        ),
+        .testTarget(
+            name: "DateToolsSwiftTests",
+            dependencies: ["DateToolsSwift"],
+            path: "DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests"
+        )
     ]
 )
-package.exclude = ["DateTools", "Examples", "Tests", "DateToolsSwift/Examples"]


### PR DESCRIPTION
This PR is adding support for SwiftPM. At the moment, the tests compile, but crashes when you run due to `DateTools.bundle` not being in the final bundle. Adding resources file to swiftpm has been recently added in [SE-0271](https://github.com/apple/swift-evolution/blob/master/proposals/0271-package-manager-resources.md), but at the time of submitting this PR, it's not included in any available Swift snapshots or Xcode11.4b1 version. When it lands in public, the tests can be fixed also in addition to adding `DateTools.bundle` as a resource. This is similar to https://github.com/MatthewYork/DateTools/pull/285 PR.

Just note that for using SwiftPM at the moment, developers need to add `DateTools.bundle` manually to their codebase. Might worth to also update Readme file to mention SwiftPM integration and the necessity of adding the bundle file.