### PR TITLE
SwiftPM 5.3 support with resource bundle and watchOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ DerivedData
 
 #CocoaPods
 Pods
+
+#swiftpm
+.swiftpm
+*.xcodeproj

--- a/DateToolsSwift/DateTools/Date+Bundle.swift
+++ b/DateToolsSwift/DateTools/Date+Bundle.swift
@@ -9,10 +9,25 @@
 import Foundation
 
 public extension Bundle {
-  
-  class func dateToolsBundle() -> Bundle {
-    let assetPath = Bundle(for: Constants.self).resourcePath!
-    return Bundle(path: NSString(string: assetPath).appendingPathComponent("DateTools.bundle"))!
-  }
+    
+    class func dateToolsBundle() -> Bundle {
+        let containerBundle: Bundle
+        
+        #if SWIFT_PACKAGE
+        containerBundle = Bundle.module
+        #else
+        containerBundle = Bundle(for: Constants.self)
+        #endif
+        
+        guard
+            let dateToolsBundleURL = containerBundle.url(forResource: "DateTools", withExtension: "bundle"),
+            let dateToolsBundle = Bundle(url: dateToolsBundleURL)
+        else {
+            assertionFailure("Make sure you have included DateTools.bundle in your app.")
+            return containerBundle
+        }
+        
+        return dateToolsBundle
+    }
 }
 

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateComparatorsExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateComparatorsExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateComparatorsTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateComponentsExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateComponentsExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateComponentsTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateFormatExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateFormatExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateFormatTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateInitsExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateInitsExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateDateToolsTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateManipulationsExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateManipulationsExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateManipulationsTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateTimeAgoExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/DateTimeAgoExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class DateTimeAgoTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/IntegerExtensionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/IntegerExtensionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class IntegerTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimeAgoTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimeAgoTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class TimeAgoTests : XCTestCase {
     
-    var formatter: DateFormatter = {
+    let formatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy MM dd HH:mm:ss.SSS"
         return formatter
@@ -39,51 +39,51 @@ class TimeAgoTests : XCTestCase {
     
     func testBasicLongTimeAgo() {
         let now: String = self.date0.timeAgo(since: self.date0)
-        XCTAssert(now.isEmpty, "'Now' is empty.")
+        XCTAssertFalse(now.isEmpty, "'Now' is empty.")
         let ago: String = self.date1.timeAgo(since: self.date0)
-        XCTAssert(ago.isEmpty, "Ago is empty.")
+        XCTAssertFalse(ago.isEmpty, "Ago is empty.")
     }
     
     func testLongTimeAgo2Days() throws {
         self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 05 18:15:12.000"))
         self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
         let ago: String = self.date0.timeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("2 days ago"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("2 days ago"))
     }
     
     func testLongTimeAgo1DayAndHalf() throws {
         self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 9:15:12.000"))
         self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
         let ago: String = self.date0.timeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("Yesterday"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("Yesterday"))
     }
     
     func testLongTimeAgoExactlyYesterday() throws {
         self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 18:15:12.000"))
         self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
         let ago: String = self.date0.timeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("Yesterday"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("Yesterday"))
     }
     
     func testLongTimeAgoLessThan24hoursButYesterday() throws {
-        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 20:15:12.000"))
-        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 00:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 22:15:12.000"))
         let ago: String = self.date0.timeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("22 hours ago"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("22 hours ago"))
     }
     
     func testLongTimeAgoLessThan24hoursSameDay() throws {
         self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
         self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
         let ago: String = self.date0.timeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("8 hours ago"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("8 hours ago"))
     }
     
     func testLongTimeAgoBetween24And48Hours() throws {
         self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
         self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 08 18:15:12.000"))
         let ago: String = self.date0.timeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("Yesterday"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("Yesterday"))
     }
     
     func testBasicShortTimeAgo() {
@@ -97,58 +97,66 @@ class TimeAgoTests : XCTestCase {
         self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 05 18:15:12.000"))
         self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
         let ago: String = self.date0.shortTimeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("2d"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("2d"))
     }
     
     func testShortTimeAgo1DayAndHalf() throws {
         self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 9:15:12.000"))
         self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
         let ago: String = self.date0.shortTimeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("1d"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("1d"))
     }
     
     func testShortTimeAgoExactlyYesterday() throws {
         self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 18:15:12.000"))
         self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
         let ago: String = self.date0.shortTimeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("1d"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("1d"))
     }
     
     func testShortTimeAgoLessThan24hoursButYesterday() throws {
-        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 20:15:12.000"))
-        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 00:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 22:15:12.000"))
         let ago: String = self.date0.shortTimeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("22h"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("22h"))
     }
     
     func testShortTimeAgoLessThan24hoursSameDay() throws {
         self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
         self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
         let ago: String = self.date0.shortTimeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("8h"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("8h"))
     }
     
     func testShortTimeAgoBetween24And48Hours() throws {
         self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
         self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 08 18:15:12.000"))
         let ago: String = self.date0.shortTimeAgo(since: self.date1)
-        XCTAssertEqual(ago, DateToolsLocalizedStrings("1d"))
+        XCTAssertEqual(ago, try DateToolsLocalizedStrings("1d"))
     }
     
     func testLongTimeAgoLocalizationsAccessible() throws {
-        let en_local: String = "Yesterday"
-        let ja_local: String = "昨日"
-        let key: String = en_local
-        let ja_result: String = DateToolsLocalizedStrings(key)
+        let en_local = "Yesterday"
+        let ja_local = "昨日"
+        let key = en_local
+        let ja_result = try DateToolsLocalizedStrings(key, for: .japanese)
         XCTAssertEqual(ja_local, ja_result, "Could not access localizations.")
     }
 }
 
 extension XCTestCase {
-    func DateToolsLocalizedStrings(_ key: String) -> String {
+    enum LanguageIdentifier: String {
+        case english = "en"
+        case japanese = "ja"
+    }
+    func DateToolsLocalizedStrings(_ key: String, for language: LanguageIdentifier = .english) throws -> String {
+        let dateToolsBundlePath = try XCTUnwrap(Bundle.module.path(forResource: "DateTools", ofType: "bundle"))
+        let dateToolsBundle = try XCTUnwrap(Bundle(path: dateToolsBundlePath))
+        let path = try XCTUnwrap(dateToolsBundle.path(forResource: language.rawValue, ofType: "lproj"))
+        let languageBundle = try XCTUnwrap(Bundle(path: path))
         return NSLocalizedString(key,
                                  tableName: "DateTools",
-                                 bundle: Bundle.dateToolsBundle(),
+                                 bundle: languageBundle,
                                  value: "",
                                  comment: "")
     }

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimeAgoTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimeAgoTests.swift
@@ -7,22 +7,29 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 
 class TimeAgoTests : XCTestCase {
     
-    var formatter: DateFormatter?
-    var date0: Date?
-    var date1: Date?
+    var formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy MM dd HH:mm:ss.SSS"
+        return formatter
+    }()
+    var date0 = Date()
+    var date1 = Date()
     
     override func setUp() {
-        super.up = nil
+        super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
-        self.formatter = DateFormatter()
-        self.formatter?.dateFormat = "yyyy MM dd HH:mm:ss.SSS"
-        self.date0 = self.formatter?.date(from: "2014 11 05 18:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
+        
+        do {
+            self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 05 18:15:12.000"))
+            self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        } catch {
+            XCTFail("Failed to format dates from string.")
+        }
     }
     
     override func tearDown() {
@@ -31,112 +38,118 @@ class TimeAgoTests : XCTestCase {
     }
     
     func testBasicLongTimeAgo() {
-        var now: String = self.date0.timeAgoSinceDate(self.date0)
-        XCTAssert(now && now.length > 0, "'Now' is nil or empty.")
-        var ago: String = self.date1.timeAgoSinceDate(self.date0)
-        XCTAssert(ago && ago.length > 0, "Ago is nil or empty.")
+        let now: String = self.date0.timeAgo(since: self.date0)
+        XCTAssert(now.isEmpty, "'Now' is empty.")
+        let ago: String = self.date1.timeAgo(since: self.date0)
+        XCTAssert(ago.isEmpty, "Ago is empty.")
     }
     
-    func testLongTimeAgo2Days() {
-        self.date0 = self.formatter?.date(from: "2014 11 05 18:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("2 days ago"))
+    func testLongTimeAgo2Days() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 05 18:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("2 days ago"))
     }
     
-    func testLongTimeAgo1DayAndHalf() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 9:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("Yesterday"))
+    func testLongTimeAgo1DayAndHalf() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 9:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("Yesterday"))
     }
     
-    func testLongTimeAgoExactlyYesterday() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 18:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("Yesterday"))
+    func testLongTimeAgoExactlyYesterday() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 18:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("Yesterday"))
     }
     
-    func testLongTimeAgoLessThan24hoursButYesterday() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 20:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("22 hours ago"))
+    func testLongTimeAgoLessThan24hoursButYesterday() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 20:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("22 hours ago"))
     }
     
-    func testLongTimeAgoLessThan24hoursSameDay() {
-        self.date0 = self.formatter?.date(from: "2014 11 07 10:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("8 hours ago"))
+    func testLongTimeAgoLessThan24hoursSameDay() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("8 hours ago"))
     }
     
-    func testLongTimeAgoBetween24And48Hours() {
-        self.date0 = self.formatter?.date(from: "2014 11 07 10:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 08 18:15:12.000")
-        var ago: String = self.date0.timeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("Yesterday"))
+    func testLongTimeAgoBetween24And48Hours() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 08 18:15:12.000"))
+        let ago: String = self.date0.timeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("Yesterday"))
     }
     
     func testBasicShortTimeAgo() {
-        var now: String = self.date0.shortTimeAgoSinceDate(self.date0)
-        XCTAssert(now && now.length > 0, "'Now' is nil or empty.")
-        var ago: String = self.date1.shortTimeAgoSinceDate(self.date0)
-        XCTAssert(ago && ago.length > 0, "Ago is nil or empty.")
+        let now: String = self.date0.shortTimeAgo(since: self.date0)
+        XCTAssertFalse(now.isEmpty, "'Now' is empty.")
+        let ago: String = self.date1.shortTimeAgo(since: self.date0)
+        XCTAssertFalse(ago.isEmpty, "Ago is empty.")
     }
     
-    func testShortTimeAgo2Days() {
-        self.date0 = self.formatter?.date(from: "2014 11 05 18:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("2d"))
+    func testShortTimeAgo2Days() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 05 18:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("2d"))
     }
     
-    func testShortTimeAgo1DayAndHalf() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 9:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("1d"))
+    func testShortTimeAgo1DayAndHalf() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 9:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("1d"))
     }
     
-    func testShortTimeAgoExactlyYesterday() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 18:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("1d"))
+    func testShortTimeAgoExactlyYesterday() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 18:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("1d"))
     }
     
-    func testShortTimeAgoLessThan24hoursButYesterday() {
-        self.date0 = self.formatter?.date(from: "2014 11 06 20:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("22h"))
+    func testShortTimeAgoLessThan24hoursButYesterday() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 06 20:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("22h"))
     }
     
-    func testShortTimeAgoLessThan24hoursSameDay() {
-        self.date0 = self.formatter?.date(from: "2014 11 07 10:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 07 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("8h"))
+    func testShortTimeAgoLessThan24hoursSameDay() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("8h"))
     }
     
-    func testShortTimeAgoBetween24And48Hours() {
-        self.date0 = self.formatter?.date(from: "2014 11 07 10:15:12.000")
-        self.date1 = self.formatter?.date(from: "2014 11 08 18:15:12.000")
-        var ago: String = self.date0.shortTimeAgoSinceDate(self.date1)
-        XCTAssertEqualObjects(ago, DateToolsLocalizedStrings("1d"))
+    func testShortTimeAgoBetween24And48Hours() throws {
+        self.date0 = try XCTUnwrap(self.formatter.date(from: "2014 11 07 10:15:12.000"))
+        self.date1 = try XCTUnwrap(self.formatter.date(from: "2014 11 08 18:15:12.000"))
+        let ago: String = self.date0.shortTimeAgo(since: self.date1)
+        XCTAssertEqual(ago, DateToolsLocalizedStrings("1d"))
     }
     
-    func testLongTimeAgoLocalizationsAccessible() {
-        var en_local: String = "Yesterday"
-        var ja_local: String = "昨日"
-        var key: String = en_local
-        var path: String = NSBundlemainBundle.bundlePath.stringByAppendingPathComponent("DateTools.bundle/ja.lproj")
-        var bundle: Bundle = Bundle(path: path)!
-        var ja_result: String = NSLocalizedStringFromTableInBundle(key, "DateTools", bundle, nil)
-        XCTAssertEqualObjects(ja_local, ja_result, "Could not access localizations.")
+    func testLongTimeAgoLocalizationsAccessible() throws {
+        let en_local: String = "Yesterday"
+        let ja_local: String = "昨日"
+        let key: String = en_local
+        let ja_result: String = DateToolsLocalizedStrings(key)
+        XCTAssertEqual(ja_local, ja_result, "Could not access localizations.")
     }
-    
 }
 
+extension XCTestCase {
+    func DateToolsLocalizedStrings(_ key: String) -> String {
+        return NSLocalizedString(key,
+                                 tableName: "DateTools",
+                                 bundle: Bundle.dateToolsBundle(),
+                                 value: "",
+                                 comment: "")
+    }
+}

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimeChunkTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimeChunkTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class TimeChunkTests: XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodChainTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodChainTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 
 class TimePeriodChainTests : XCTestCase {

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodCollectionTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodCollectionTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class TimePeriodCollectionTests : XCTestCase {
     

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodGroupTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodGroupTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 
 class TimePeriodGroupTests : XCTestCase {

--- a/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodTests.swift
+++ b/DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests/TimePeriodTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import DateToolsTests
+@testable import DateToolsSwift
 
 class TimePeriodTests : XCTestCase {
     

--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,30 @@
+// swift-tools-version:5.1
+
 import PackageDescription
 
 let package = Package(
     name: "DateToolsSwift",
+    platforms: [
+        .macOS(.v10_10), .iOS(.v8)
+    ],
+    products: [
+        .library(
+            name: "DateToolsSwift",
+            targets: ["DateToolsSwift"])
+    ],
     targets: [
-        Target(name: "DateToolsSwift")
+        .target(
+            name: "DateToolsSwift",
+            path: "DateToolsSwift/DateTools",
+            exclude: [
+                "Examples",
+                "DateToolsSwift/Examples"
+            ]
+        ),
+        .testTarget(
+            name: "DateToolsSwiftTests",
+            dependencies: ["DateToolsSwift"],
+            path: "DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests"
+        )
     ]
 )
-package.exclude = ["DateTools", "Examples", "Tests", "DateToolsSwift/Examples"]

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 
 let package = Package(
     name: "DateToolsSwift",
     platforms: [
-        .macOS(.v10_10), .iOS(.v8)
+        .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(
@@ -19,12 +19,21 @@ let package = Package(
             exclude: [
                 "Examples",
                 "DateToolsSwift/Examples"
+            ],
+            resources: [
+                .copy("DateTools.bundle")
             ]
         ),
         .testTarget(
             name: "DateToolsSwiftTests",
             dependencies: ["DateToolsSwift"],
-            path: "DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests"
+            path: "DateToolsSwift/Tests/DateToolsTests/DateToolsTestsTests",
+            exclude: [
+                "Info.plist"
+            ],
+            resources: [
+                .copy("DateTools.bundle")
+            ]
         )
     ]
 )


### PR DESCRIPTION
This is currently WIP due to Swift 5.3 being in beta. This CR includes the work for fixing the unit tests in addition to prevent app crashing due to unavailability of the bundle. This is based on the https://github.com/MatthewYork/DateTools/pull/291 PR, but if that branch deosn't get merged in by the time Xcode 12 / Swift 5.3 is released, this can be cleaned up and used instead and the other PR should be disregarded.